### PR TITLE
Do not parse input that exceeds 124 characters - prevents regex crashing

### DIFF
--- a/src/main/java/com/codingame/game/Referee.java
+++ b/src/main/java/com/codingame/game/Referee.java
@@ -393,6 +393,10 @@ public class Referee extends AbstractReferee {
     }
 
     private Action parseAction(String action) throws InvalidAction {
+        if (action.length() > Constants.MAX_INPUT_LENGTH) {
+            throw new InvalidAction("exceeded number of allowed characters");
+        }
+
         Matcher matchPush = Constants.PLAYER_INPUT_PUSH_PATTERN.matcher(action);
         Matcher matchMove = Constants.PLAYER_INPUT_MOVE_PATTERN.matcher(action);
         Matcher matchMaxSteps = Constants.PLAYER_INPUT_MOVE_MAX_STEPS_PATTERN.matcher(action);

--- a/src/main/java/com/codingame/game/Utils/Constants.java
+++ b/src/main/java/com/codingame/game/Utils/Constants.java
@@ -89,6 +89,7 @@ public class Constants {
     //make sure the number of GAME turns is EVEN for equal number of PUSH and MOVE turns
     public static final int MAX_GAME_TURNS = 150;
     public static final int MAX_MOVE_STEPS = 20;
+    public static final int MAX_INPUT_LENGTH = 124;
 
     public static final Pattern PLAYER_INPUT_PUSH_PATTERN = Pattern
             .compile("(?<pushAction>\\bPUSH\\b) (?<id>[ 0-" + (MAP_SIZE - 1) + "]) (?<direction>(\\bUP\\b|\\bRIGHT\\b|\\bDOWN\\b|\\bLEFT\\b))");


### PR DESCRIPTION
"MOVE RIGHT RIGHT RIGHT RIGHT RIGHT RIGHT RIGHT RIGHT RIGHT RIGHT RIGHT RIGHT RIGHT RIGHT RIGHT RIGHT RIGHT RIGHT RIGHT RIGHT" would be the longest input accepted, which has 124 characters.