### PR TITLE
Fixed push message before deadlock

### DIFF
--- a/src/main/java/com/codingame/game/Referee.java
+++ b/src/main/java/com/codingame/game/Referee.java
@@ -301,6 +301,8 @@ public class Referee extends AbstractReferee {
             }
 
             if (numStalePushTurns >= maxStaleTurns) {
+                //allows the last push message to be displayed in the summary
+                forceAnimationFrame();
                 gameManager.addToGameSummary(GameManager.formatErrorMessage("The game ended in a deadlock!"));
                 forceGameEnd();
             }


### PR DESCRIPTION
Fixed a small bug where the last push message didn't appear in the summary before the deadlock occurred.

Was tested using the following code as Player's outputs:
```
if (turnType == 0) {
    System.out.println("PUSH 1 UP");
 } else {
    System.out.println("PASS");
 }
```
